### PR TITLE
Add a CMake option ROCM_DEVICELIB_ENABLE_TESTING that can disable testing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,10 +68,14 @@ add_subdirectory(opencl)
 add_subdirectory(hip)
 add_subdirectory(asanrtl)
 
-enable_testing()
-add_subdirectory(test/compile)
-
-include(Packages)
+# Conditionally enable testing.
+if(NOT DEFINED ROCM_DEVICELIB_ENABLE_TESTING)
+  set(ROCM_DEVICELIB_ENABLE_TESTING ON)
+endif()
+if(ROCM_DEVICELIB_ENABLE_TESTING)
+  enable_testing()
+  add_subdirectory(test/compile)
+endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   ## CPack standard variables


### PR DESCRIPTION
This is useful when included in super-projects which use ctest and do not wish to test sub-projects.